### PR TITLE
Update process to check for before opening new service instance

### DIFF
--- a/unity_pupil_plugin/Assets/pupil_plugin/Scripts/Pupil/PupilTools.cs
+++ b/unity_pupil_plugin/Assets/pupil_plugin/Scripts/Pupil/PupilTools.cs
@@ -403,10 +403,10 @@ public class PupilTools : MonoBehaviour
 		if (File.Exists (servicePath))
 		{
 		
-			if (Process.GetProcessesByName ("pupil_capture").Length > 0)
+			if (Process.GetProcessesByName ("pupil_service").Length > 0)
 			{
 			
-				UnityEngine.Debug.LogWarning (" Pupil Capture is already running ! ");
+				UnityEngine.Debug.LogWarning (" Pupil Service is already running ! ");
 			
 			} else
 			{


### PR DESCRIPTION
Pupil tools was looking for the pupil capture process running as opposed to the pupil service process when starting a new instance of pupil service.