### PR TITLE
Avoid restarting NetworkAPIPlugin

### DIFF
--- a/plugin/Scripts/FrameListener.cs
+++ b/plugin/Scripts/FrameListener.cs
@@ -9,7 +9,7 @@ namespace PupilLabs
     {
         public event Action<int, byte[]> OnReceiveEyeFrame;
 
-        public FrameListener(SubscriptionsController subsCtrl) : base(subsCtrl) {}
+        public FrameListener(SubscriptionsController subsCtrl) : base(subsCtrl) { }
 
         protected override void CustomEnable()
         {

--- a/plugin/Scripts/FrameListener.cs
+++ b/plugin/Scripts/FrameListener.cs
@@ -16,7 +16,10 @@ namespace PupilLabs
             Debug.Log("Enabling Frame Listener");
 
             subsCtrl.SubscribeTo("frame.eye.", CustomReceiveData);
-            subsCtrl.requestCtrl.StartPlugin("NetworkApiPlugin");
+            subsCtrl.requestCtrl.Send(new Dictionary<string, object> {
+                {"subject", "frame_publishing.set_format"},
+                {"format", "jpeg"}
+            });
         }
 
         protected override void CustomDisable()


### PR DESCRIPTION
The NetworkAPIPlugin is now always running by default and should not be restarted every time we start HMD-Eyes. Instead, it should be sufficient to reset the required frame format.

I used the default vscode C# formatter, which put the extra space between `{ }`.

✔️ Tested without HMD, but with a core headset. I think this should be working nevertheless.