### PR TITLE
Remove duplicated sending of reference data

### DIFF
--- a/plugin/Scripts/Calibration.cs
+++ b/plugin/Scripts/Calibration.cs
@@ -73,12 +73,6 @@ namespace PupilLabs
             calibrationData.Add(new Dictionary<string, object>() {
                 { settings.PositionKey, position },
                 { "timestamp", timestamp },
-                { "id", int.Parse(Helpers.rightEyeID) }
-            });
-            calibrationData.Add(new Dictionary<string, object>() {
-                { settings.PositionKey, position },
-                { "timestamp", timestamp },
-                { "id", int.Parse(Helpers.leftEyeID) }
             });
         }
 


### PR DESCRIPTION
We only send the reference point, which is independent of the eye-id.

✔️ Tested by calibrating with a core headset connected to Unity. The calibration was bad (as to be expected), but everything worked fine.