### PR TITLE
Add better logs for missing component references

### DIFF
--- a/plugin/Scripts/CalibrationController.cs
+++ b/plugin/Scripts/CalibrationController.cs
@@ -46,9 +46,40 @@ namespace PupilLabs
             calibration.OnCalibrationSucceeded += CalibrationSucceeded;
             calibration.OnCalibrationFailed += CalibrationFailed;
 
-            if (subsCtrl == null || timeSync == null || marker == null || camera == null || settings == null || targets == null)
+            bool allReferencesValid = true;
+            if (subsCtrl == null)
             {
-                Debug.LogWarning("Required components missing.");
+                Debug.LogError("SubscriptionsController reference missing!");
+                allReferencesValid = false;
+            }
+            if (timeSync == null)
+            {
+                Debug.LogError("TimeSync reference missing!");
+                allReferencesValid = false;
+            }
+            if (marker == null)
+            {
+                Debug.LogError("Marker reference missing!");
+                allReferencesValid = false;
+            }
+            if (camera == null)
+            {
+                Debug.LogError("Camera reference missing!");
+                allReferencesValid = false;
+            }
+            if (settings == null)
+            {
+                Debug.LogError("CalibrationSettings reference missing!");
+                allReferencesValid = false;
+            }
+            if (targets == null)
+            {
+                Debug.LogError("CalibrationTargets reference missing!");
+                allReferencesValid = false;
+            }
+            if (!allReferencesValid)
+            {
+                Debug.LogError("CalibrationController is missing required references to other components. Please connect the references, or the component won't work correctly.");
                 enabled = false;
                 return;
             }
@@ -258,7 +289,7 @@ namespace PupilLabs
             {
                 return;
             }
-            
+
             Gizmos.matrix = camera.transform.localToWorldMatrix;
             for (int i = 0; i < targets.GetTargetCount(); ++i)
             {

--- a/plugin/Scripts/FrameVisualizer.cs
+++ b/plugin/Scripts/FrameVisualizer.cs
@@ -10,7 +10,7 @@ namespace PupilLabs
         public Transform cameraAsParent;
         public Material eyeFrameMaterial;
         [Header("Settings")]
-        [Tooltip("Used for adjusting the Eye Frames, restart needed!")]
+        [Tooltip("Used for adjusting the Eye Frames. Changes require restarting play mode!")]
         public bool model200Hz;
 
         public int targetFPS = 20;
@@ -142,5 +142,4 @@ namespace PupilLabs
         }
     }
 }
-
 

--- a/plugin/Scripts/FrameVisualizer.cs
+++ b/plugin/Scripts/FrameVisualizer.cs
@@ -10,7 +10,7 @@ namespace PupilLabs
         public Transform cameraAsParent;
         public Material eyeFrameMaterial;
         [Header("Settings")]
-        [Tooltip("Used for adjusting the Eye Frames, restart needed!")] 
+        [Tooltip("Used for adjusting the Eye Frames, restart needed!")]
         public bool model200Hz;
 
         public int targetFPS = 20;
@@ -24,9 +24,25 @@ namespace PupilLabs
 
         void OnEnable()
         {
-            if (cameraAsParent == null || subscriptionsController == null || eyeFrameMaterial == null)
+            bool allReferencesValid = true;
+            if (cameraAsParent == null)
             {
-                Debug.LogWarning("Required components missing!");
+                Debug.LogError("Camera reference 'cameraAsParent' missing!");
+                allReferencesValid = false;
+            }
+            if (subscriptionsController == null)
+            {
+                Debug.LogError("SubscriptionsController reference missing!");
+                allReferencesValid = false;
+            }
+            if (eyeFrameMaterial == null)
+            {
+                Debug.LogError("EyeFrameMaterial reference missing!");
+                allReferencesValid = false;
+            }
+            if (!allReferencesValid)
+            {
+                Debug.LogError("FrameVisualizer is missing required references to other components. Please connect the references, or the component won't work correctly.");
                 enabled = false;
                 return;
             }

--- a/plugin/Scripts/GazeController.cs
+++ b/plugin/Scripts/GazeController.cs
@@ -8,14 +8,14 @@ namespace PupilLabs
         public SubscriptionsController subscriptionsController;
 
         public event Action<GazeData> OnReceive3dGaze;
-        
+
         GazeListener listener;
 
         void OnEnable()
         {
             if (subscriptionsController == null)
             {
-                Debug.LogWarning("Required components missing.");
+                Debug.LogError("GazeController is missing the required SubscriptionsController reference. Please connect the reference, or the component won't work correctly.");
                 enabled = false;
                 return;
             }
@@ -25,8 +25,8 @@ namespace PupilLabs
                 listener = new GazeListener(subscriptionsController);
                 listener.OnReceive3dGaze += Forward3dGaze;
             }
-            
-            listener.Enable();            
+
+            listener.Enable();
         }
 
         void OnDisable()

--- a/plugin/Scripts/GazeVisualizer.cs
+++ b/plugin/Scripts/GazeVisualizer.cs
@@ -36,27 +36,41 @@ namespace PupilLabs
 
         void OnEnable()
         {
-            if (projectionMarker == null || gazeDirectionMarker == null)
+            bool allReferencesValid = true;
+            if (projectionMarker == null)
             {
-                Debug.LogWarning("Marker reference missing.");
+                Debug.LogError("ProjectionMarker reference missing!");
+                allReferencesValid = false;
+            }
+            if (gazeDirectionMarker == null)
+            {
+                Debug.LogError("GazeDirectionMarker reference missing!");
+                allReferencesValid = false;
+            }
+            if (gazeOrigin == null)
+            {
+                Debug.LogError("GazeOrigin reference missing!");
+                allReferencesValid = false;
+            }
+            if (gazeController == null)
+            {
+                Debug.LogError("GazeController reference missing!");
+                allReferencesValid = false;
+            }
+            if (!allReferencesValid)
+            {
+                Debug.LogError("GazeVisualizer is missing required references to other components. Please connect the references, or the component won't work correctly.");
                 enabled = false;
                 return;
             }
+
             origMarkerScale = gazeDirectionMarker.localScale;
-
-            if (gazeOrigin == null || gazeController == null)
-            {
-                Debug.LogWarning("Required components missing.");
-                enabled = false;
-                return;
-            }
-
             targetRenderer = gazeDirectionMarker.GetComponent<MeshRenderer>();
 
             StartVisualizing();
         }
 
-        void OnDisable() 
+        void OnDisable()
         {
             if (gazeDirectionMarker != null)
             {
@@ -136,7 +150,7 @@ namespace PupilLabs
             {
                 return;
             }
-            
+
             localGazeDirection = gazeData.GazeDirection;
             gazeDistance = gazeData.GazeDistance;
         }
@@ -154,7 +168,7 @@ namespace PupilLabs
         void ShowProjected()
         {
             gazeDirectionMarker.localScale = origMarkerScale;
-            
+
             Vector3 origin = gazeOrigin.position;
             Vector3 direction = gazeOrigin.TransformDirection(localGazeDirection);
 

--- a/plugin/Scripts/RecordingController.cs
+++ b/plugin/Scripts/RecordingController.cs
@@ -24,7 +24,7 @@ namespace PupilLabs
         {
             if (requestCtrl == null)
             {
-                Debug.LogWarning("Request Controller missing");
+                Debug.LogError("RecordingController is missing the required RequestController reference. Please connect the reference, or the component won't work correctly.");
                 enabled = false;
                 return;
             }

--- a/plugin/Scripts/SubscriptionsController.cs
+++ b/plugin/Scripts/SubscriptionsController.cs
@@ -24,7 +24,7 @@ namespace PupilLabs
         {
             if (requestCtrl == null)
             {
-                Debug.LogWarning("RequestController missing!");
+                Debug.LogError("SubscriptionsController is missing the required RequestController reference. Please connect the reference, or the component won't work correctly.");
                 enabled = false;
                 return;
             }


### PR DESCRIPTION
Previously some users would not notice if a component was missing a connection, or did not know what to do in this case. This PR should make this a bit clearer to users by telling them which reference is missing from which component and that they need to connect them manually. It also logs an error instead of a warning since the component won't function correctly in this case.

This is especially important since we offer a range of ready-to-use prefabs, which still require to be hooked up correctly to the scene. Just dragging them in would not work because of missing references.